### PR TITLE
Add Granify job postings

### DIFF
--- a/_posts/2013-09-12-Sept-2013-Meetup.markdown
+++ b/_posts/2013-09-12-Sept-2013-Meetup.markdown
@@ -29,3 +29,7 @@ We're also excited to announce that we're moving the venue to StartupEdmonton. T
 
 * [@MarkBennett](http://twitter.com/markbennett) An Introduction to GIS and Rails, Part 1 of 3
 * [@fnichol](http://twitter.com/fnichol) An Introduction to Docker and Linux Containers
+
+## Jobs
+
+* [Granify](http://granify.com/) is looking for a [backend developer](http://granify.com/careers/backend-developer/) (Ruby and eventually Go!), as well as a [DevOps and Scalability Engineer](http://granify.com/careers/devops-engineer/). Big data, big fun.


### PR DESCRIPTION
We’re trying to get a lot of local talent but have had difficulty finding enough people who don’t already love their current gig. 

We’re downtown, we’re profitable and solving a big problem, and we don't have TPS reports.
